### PR TITLE
Fix camera in mobile viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,12 +290,19 @@
                     return false;
                 }
 
+                // Evitar ejecución dentro de un iframe (como el visor de Replit)
+                if (window !== window.parent) {
+                    this.showStatus('Abre la aplicación en una pestaña nueva para usar la cámara', 'error');
+                    this.startBtn.disabled = true;
+                    return false;
+                }
+
                 // Permitir HTTP en desarrollo local
-                const isLocalhost = location.hostname === 'localhost' || 
-                                  location.hostname === '127.0.0.1' || 
+                const isLocalhost = location.hostname === 'localhost' ||
+                                  location.hostname === '127.0.0.1' ||
                                   location.hostname.startsWith('192.168.') ||
                                   location.hostname.startsWith('10.');
-                
+
                 if (location.protocol !== 'https:' && !isLocalhost) {
                     this.showStatus('Se requiere HTTPS para acceso a cámara (excepto en localhost)', 'error');
                     this.startBtn.disabled = true;
@@ -482,7 +489,7 @@
 
         // Inicializar aplicación cuando DOM esté listo
         document.addEventListener('DOMContentLoaded', () => {
-            new ASCIICameraApp();
+            window.asciiApp = new ASCIICameraApp();
         });
 
         // Limpiar recursos al cerrar


### PR DESCRIPTION
## Summary
- check if the page is opened inside an iframe and warn the user
- store the camera app globally for cleanup

## Testing
- `git status --short`